### PR TITLE
feat(agentkit): A3M Router AgentKit adapter package

### DIFF
--- a/packages/agentkit-adapter/LICENSE
+++ b/packages/agentkit-adapter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Subho Mukherjee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agentkit-adapter/README.md
+++ b/packages/agentkit-adapter/README.md
@@ -1,0 +1,126 @@
+# A3M Router AgentKit Adapter
+
+AgentKit adapter that routes LLM calls through A3M Router for intelligent, cost-optimized model selection.
+
+## Installation
+
+```bash
+npm install @a3m/agentkit-adapter
+```
+
+## Usage
+
+```typescript
+import { createAgentKitAdapter } from '@a3m/agentkit-adapter';
+import { createAgent, run } from '@stablelib/agentkit';
+
+// Create A3M-powered adapter
+const a3mAdapter = createAgentKitAdapter({
+  baseUrl: 'http://localhost:8787',
+  model: 'auto',
+  temperature: 0.7,
+  maxTokens: 4096,
+});
+
+// Create agent with A3M routing
+const agent = createAgent({
+  name: 'a3m-assistant',
+  description: 'AI assistant powered by A3M Router',
+  llm: a3mAdapter,
+  tools: [
+    // your tools
+  ],
+});
+
+// Run the agent
+const result = await run(agent, {
+  input: 'Hello, what is 2+2?',
+});
+```
+
+## API
+
+### `createAgentKitAdapter(config)`
+
+Creates an A3M Router adapter for AgentKit.
+
+**Config options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `baseUrl` | `string` | `'http://localhost:8787'` | A3M Router server URL |
+| `model` | `string` | `'auto'` | Model to use (`'auto'` for intelligent routing) |
+| `temperature` | `number` | `0.7` | Sampling temperature |
+| `maxTokens` | `number` | `4096` | Max tokens to generate |
+| `parallelEnsemble` | `number` | `1` | Number of providers for ensemble |
+| `apiKey` | `string` | — | Optional API key |
+| `systemPrompt` | `string` | — | Optional system prompt |
+| `tools` | `AgentTool[]` | `[]` | Available tools |
+
+**Returns:** `A3MAgentKitAdapter` instance
+
+### Adapter Methods
+
+#### `chat(messages, tools?)`
+
+Send a chat completion request.
+
+```typescript
+const response = await a3mAdapter.chat([
+  { role: 'user', content: 'What is AI?' },
+]);
+```
+
+#### `stream(messages)`
+
+Stream a chat completion response.
+
+```typescript
+for await (const chunk of a3mAdapter.stream(messages)) {
+  process.stdout.write(chunk.content);
+}
+```
+
+#### `getTools()`
+
+Get configured tools for function calling.
+
+```typescript
+const tools = a3mAdapter.getTools();
+```
+
+## How It Works
+
+1. Incoming requests are forwarded to A3M Router at `baseUrl`
+2. A3M Router analyzes query complexity and routes to cheapest capable provider
+3. Response is returned with routing metadata
+4. Falls back gracefully if A3M Router is unavailable
+
+## Example with Tools
+
+```typescript
+import { createAgentKitAdapter } from '@a3m/agentkit-adapter';
+
+const calculatorTool = {
+  name: 'calculator',
+  description: 'Evaluate a mathematical expression',
+  parameters: {
+    expression: { type: 'string', description: 'The math expression to evaluate' },
+  },
+};
+
+const adapter = createAgentKitAdapter({
+  baseUrl: 'http://localhost:8787',
+  model: 'auto',
+  tools: [calculatorTool],
+});
+
+const response = await adapter.chat(
+  [{ role: 'user', content: 'What is 2+2?' }],
+  [calculatorTool]
+);
+```
+
+## License
+
+MIT

--- a/packages/agentkit-adapter/examples/agentkit-example.ts
+++ b/packages/agentkit-adapter/examples/agentkit-example.ts
@@ -1,0 +1,139 @@
+/**
+ * A3M Router AgentKit Adapter - Example Usage
+ * 
+ * Run: npx ts-node examples/agentkit-example.ts
+ */
+
+import { createAgentKitAdapter, A3MAdapterConfig } from '../src';
+
+// Example 1: Basic chat
+async function basicChat() {
+  console.log('=== Example 1: Basic Chat ===');
+  
+  const adapter = createAgentKitAdapter({
+    baseUrl: 'http://localhost:8787',
+    model: 'auto',
+    temperature: 0.7,
+  });
+
+  const response = await adapter.chat([
+    { role: 'user', content: 'What is 2+2?' },
+  ]);
+
+  console.log('Response:', response.content);
+  console.log('Provider:', response.provider);
+  console.log('Model:', response.model);
+  console.log('Tier:', response.tier);
+  console.log();
+}
+
+// Example 2: Streaming
+async function streamingChat() {
+  console.log('=== Example 2: Streaming ===');
+  
+  const adapter = createAgentKitAdapter({
+    baseUrl: 'http://localhost:8787',
+    model: 'auto',
+  });
+
+  process.stdout.write('Stream: ');
+  for await (const chunk of adapter.stream([
+    { role: 'user', content: 'Count to 5' },
+  ])) {
+    process.stdout.write(chunk.content);
+  }
+  console.log('\n');
+}
+
+// Example 3: With tools
+async function toolChat() {
+  console.log('=== Example 3: With Tools ===');
+  
+  const calculatorTool = {
+    name: 'calculator',
+    description: 'Evaluate a mathematical expression',
+    parameters: {
+      type: 'object',
+      properties: {
+        expression: { 
+          type: 'string', 
+          description: 'The math expression to evaluate' 
+        },
+      },
+      required: ['expression'],
+    },
+  };
+
+  const weatherTool = {
+    name: 'get_weather',
+    description: 'Get current weather for a location',
+    parameters: {
+      type: 'object',
+      properties: {
+        location: { 
+          type: 'string', 
+          description: 'City name' 
+        },
+      },
+      required: ['location'],
+    },
+  };
+
+  const adapter = createAgentKitAdapter({
+    baseUrl: 'http://localhost:8787',
+    model: 'auto',
+    temperature: 0.7,
+    tools: [calculatorTool, weatherTool],
+  });
+
+  const response = await adapter.chat(
+    [
+      { 
+        role: 'user', 
+        content: 'What is the weather in San Francisco and what is 50 * 23?' 
+      },
+    ],
+    [calculatorTool, weatherTool]
+  );
+
+  console.log('Response:', response.content);
+  console.log('Provider:', response.provider);
+  console.log('Tool Calls:', response.toolCalls);
+  console.log();
+}
+
+// Example 4: Parallel ensemble
+async function ensembleChat() {
+  console.log('=== Example 4: Parallel Ensemble ===');
+  
+  const adapter = createAgentKitAdapter({
+    baseUrl: 'http://localhost:8787',
+    model: 'auto',
+    parallelEnsemble: 3,  // Call 3 providers, pick best
+  });
+
+  const response = await adapter.chat([
+    { role: 'user', content: 'Explain quantum entanglement in one sentence' },
+  ]);
+
+  console.log('Best provider:', response.provider);
+  console.log('Response:', response.content);
+  console.log('All candidates:', response.candidates);
+  console.log();
+}
+
+// Main
+async function main() {
+  try {
+    await basicChat();
+    await streamingChat();
+    await toolChat();
+    await ensembleChat();
+    console.log('All examples completed!');
+  } catch (error) {
+    console.error('Error:', error);
+    console.log('\nMake sure A3M Router is running: npx a3m-router serve');
+  }
+}
+
+main();

--- a/packages/agentkit-adapter/package.json
+++ b/packages/agentkit-adapter/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@a3m/agentkit-adapter",
+  "version": "1.0.0",
+  "description": "A3M Router adapter for AgentKit - enables AI agents with intelligent multi-provider routing",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "test": "vitest",
+    "lint": "eslint src/",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "agentkit",
+    "a3m",
+    "router",
+    "llm",
+    "multi-provider",
+    "ai",
+    "agent",
+    "openai",
+    "anthropic",
+    "routing"
+  ],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "@inngest/agent-kit": ">=0.0.1"
+  },
+  "dependencies": {
+    "@inngest/ai": ">=0.1.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@inngest/agent-kit": "^0.13.0",
+    "@types/node": "^20.10.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Das-rebel/adaptive-memory-multi-model-router"
+  }
+}

--- a/packages/agentkit-adapter/src/adapter.ts
+++ b/packages/agentkit-adapter/src/adapter.ts
@@ -1,0 +1,381 @@
+/**
+ * A3M Router AgentKit Adapter
+ * 
+ * Wraps A3M Router as an AgentKit-compatible LLM backend.
+ * Supports tool calling, streaming, and parallel ensemble mode.
+ */
+
+import { type AiAdapter } from "@inngest/ai";
+import { z } from "zod";
+import { stringifyError } from "./util";
+import type {
+  A3MConfig,
+  A3MInferenceOptions,
+  A3MMessage,
+  A3MTool,
+  A3MStreamChunk,
+  A3MToolCall,
+} from "./types";
+
+/**
+ * A3M Router adapter for AgentKit
+ */
+export class A3MAdapter {
+  private config: Required<A3MConfig>;
+  private format: AiAdapter.Format = "openai-chat";
+  private url: string;
+  private authKey: string = "";
+
+  constructor(config: A3MConfig = {}) {
+    this.config = {
+      baseUrl: config.baseUrl || "http://localhost:8787",
+      apiKey: config.apiKey || "",
+      defaultModel: config.defaultModel || "",
+      parallel: config.parallel ?? false,
+      temperature: config.temperature ?? 0.7,
+      maxTokens: config.maxTokens ?? 4096,
+      headers: config.headers || {},
+    };
+    this.url = `${this.config.baseUrl}/v1/chat/completions`;
+    this.authKey = this.config.apiKey;
+  }
+
+  /**
+   * Get the adapter format
+   */
+  getFormat(): AiAdapter.Format {
+    return this.format;
+  }
+
+  /**
+   * Get adapter options (required by AgentKit)
+   */
+  getOptions(): AiAdapter.Any["options"] {
+    return {
+      model: this.config.defaultModel || "auto",
+      apiKey: this.config.apiKey,
+      baseUrl: this.config.baseUrl,
+    } as AiAdapter.Any["options"];
+  }
+
+  /**
+   * Convert AgentKit messages to A3M format
+   */
+  private convertMessages(messages: Array<{
+    type: string;
+    role?: string;
+    content?: string;
+    tool?: { id?: string; name?: string };
+    tools?: unknown[];
+  }>): A3MMessage[] {
+    return messages.map((m) => {
+      if (m.type === "tool_result") {
+        return {
+          role: "tool" as const,
+          content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+          toolCallId: m.tool?.id,
+        };
+      }
+      if (m.type === "tool_call") {
+        // Tool calls are handled separately
+        return {
+          role: "assistant" as const,
+          content: "",
+        };
+      }
+      return {
+        role: (m.role as "user" | "assistant" | "system") || "user",
+        content: m.content || "",
+      };
+    }).filter((m) => m.content || m.role === "system");
+  }
+
+  /**
+   * Convert AgentKit tools to A3M/OpenAI format
+   */
+  private convertTools(tools: Array<{
+    name: string;
+    description?: string;
+    parameters?: z.ZodType<unknown>;
+    strict?: boolean;
+  }>) {
+    return tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description || "",
+        parameters: t.parameters ? z.toJSONSchema(t.parameters, { target: "draft-7" }) : undefined,
+        strict: t.strict ?? Boolean(t.parameters),
+      },
+    }));
+  }
+
+  /**
+   * Parse A3M/OpenAI response to AgentKit messages
+   */
+  private parseResponse(input: Record<string, unknown>): Array<{
+    type: string;
+    role?: string;
+    content?: string;
+    tools?: A3MToolCall[];
+    stop_reason?: string;
+  }> {
+    const result: Array<{
+      type: string;
+      role?: string;
+      content?: string;
+      tools?: A3MToolCall[];
+      stop_reason?: string;
+    }> = [];
+
+    if (input.error) {
+      throw new Error(`A3M request failed: ${JSON.stringify(input.error)}`);
+    }
+
+    const choices = (input.choices as Array<Record<string, unknown>>) || [];
+    
+    for (const choice of choices) {
+      const message = choice.message as Record<string, unknown> || {};
+      const finishReason = choice.finish_reason as string || "stop";
+
+      // Text content
+      if (message.content && (message.content as string).trim()) {
+        result.push({
+          type: "text",
+          role: message.role as string,
+          content: message.content as string,
+          stop_reason: finishReason,
+        });
+      }
+
+      // Tool calls
+      const toolCalls = message.tool_calls as Array<Record<string, unknown>> || [];
+      if (toolCalls.length > 0) {
+        result.push({
+          type: "tool_call",
+          role: message.role as string,
+          tools: toolCalls.map((tc) => ({
+            id: tc.id as string,
+            name: (tc.function as Record<string, string>)?.name || "",
+            arguments: JSON.parse((tc.function as Record<string, string>)?.arguments || "{}"),
+          })),
+          stop_reason: "tool",
+        });
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Run inference through A3M Router
+   */
+  async infer(
+    stepID: string,
+    messages: Array<{
+      type: string;
+      role?: string;
+      content?: string;
+      tool?: { id?: string; name?: string };
+      tools?: unknown[];
+    }>,
+    tools: Array<{
+      name: string;
+      description?: string;
+      parameters?: z.ZodType<unknown>;
+      strict?: boolean;
+    }>,
+    toolChoice: "auto" | "none" | { type: "function"; function: { name: string } } = "auto",
+    options: A3MInferenceOptions = {}
+  ): Promise<{
+    output: Array<{ type: string; role?: string; content?: string; tools?: A3MToolCall[]; stop_reason?: string }>;
+    raw: Record<string, unknown>;
+  }> {
+    const body: Record<string, unknown> = {
+      model: options.model || this.config.defaultModel || "auto",
+      messages: this.convertMessages(messages),
+      temperature: options.temperature ?? this.config.temperature,
+      max_tokens: options.maxTokens ?? this.config.maxTokens,
+    };
+
+    if (tools.length > 0) {
+      body.tools = this.convertTools(tools);
+      if (toolChoice === "auto") {
+        body.tool_choice = "auto";
+      } else if (toolChoice === "none") {
+        body.tool_choice = "none";
+      } else if (toolChoice && typeof toolChoice === "object") {
+        body.tool_choice = {
+          type: "function",
+          function: { name: toolChoice.function.name },
+        };
+      }
+    }
+
+    if (options.provider) {
+      body.provider = options.provider;
+    }
+
+    if (options.stop) {
+      body.stop = options.stop;
+    }
+
+    // Parallel ensemble mode
+    if (options.parallel ?? this.config.parallel) {
+      body.parallel = true;
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...this.config.headers,
+    };
+
+    if (this.authKey) {
+      headers["Authorization"] = `Bearer ${this.authKey}`;
+    }
+
+    try {
+      const response = await fetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(`A3M request failed: ${response.status} ${response.statusText}`);
+      }
+
+      const result = (await response.json()) as Record<string, unknown>;
+      return {
+        output: this.parseResponse(result),
+        raw: result,
+      };
+    } catch (err) {
+      throw new Error(`A3M inference error: ${stringifyError(err)}`);
+    }
+  }
+
+  /**
+   * Stream inference through A3M Router
+   */
+  async *stream(
+    messages: A3MMessage[],
+    tools: A3MTool[] = [],
+    options: A3MInferenceOptions = {}
+  ): AsyncGenerator<A3MStreamChunk> {
+    const body: Record<string, unknown> = {
+      model: options.model || this.config.defaultModel || "auto",
+      messages,
+      temperature: options.temperature ?? this.config.temperature,
+      max_tokens: options.maxTokens ?? this.config.maxTokens,
+      stream: true,
+    };
+
+    if (tools.length > 0) {
+      body.tools = this.convertTools(tools);
+      body.tool_choice = "auto";
+    }
+
+    if (options.provider) {
+      body.provider = options.provider;
+    }
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...this.config.headers,
+    };
+
+    if (this.authKey) {
+      headers["Authorization"] = `Bearer ${this.authKey}`;
+    }
+
+    try {
+      const response = await fetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        throw new Error(`A3M stream failed: ${response.status} ${response.statusText}`);
+      }
+
+      if (!response.body) {
+        throw new Error("A3M stream: no response body");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith("data: ")) continue;
+
+          const data = trimmed.slice(6);
+          if (data === "[DONE]") {
+            yield { type: "done" };
+            return;
+          }
+
+          try {
+            const chunk = JSON.parse(data) as Record<string, unknown>;
+            const delta = chunk.choices?.[0]?.delta as Record<string, unknown>;
+
+            if (delta?.content) {
+              yield { type: "text", content: delta.content as string };
+            }
+
+            if (delta?.tool_calls) {
+              for (const tc of delta.tool_calls as Array<Record<string, unknown>>) {
+                yield {
+                  type: "tool_call",
+                  toolCall: {
+                    id: tc.id as string,
+                    name: (tc.function as Record<string, string>)?.name || "",
+                    arguments: JSON.parse((tc.function as Record<string, string>)?.arguments || "{}"),
+                  },
+                };
+              }
+            }
+          } catch {
+            // Skip malformed JSON
+          }
+        }
+      }
+
+      yield { type: "done" };
+    } catch (err) {
+      yield { type: "error", error: stringifyError(err) };
+    }
+  }
+
+  /**
+   * Check if A3M Router is available
+   */
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.config.baseUrl}/health`, {
+        method: "GET",
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Create an A3M adapter with default settings
+ */
+export function createA3MAdapter(config?: A3MConfig): A3MAdapter {
+  return new A3MAdapter(config);
+}

--- a/packages/agentkit-adapter/src/index.ts
+++ b/packages/agentkit-adapter/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * A3M Router AgentKit Adapter
+ * 
+ * @example
+ * ```typescript
+ * import { createAgenticModelFromAiAdapter } from "@inngest/agent-kit";
+ * import { createA3MAdapter } from "@a3m/agentkit-adapter";
+ * 
+ * // Create A3M adapter
+ * const a3m = createA3MAdapter({
+ *   baseUrl: "http://localhost:8787",
+ *   parallel: true,  // Enable parallel ensemble mode
+ * });
+ * 
+ * // Wrap as AgentKit model
+ * const model = createAgenticModelFromAiAdapter(a3m as unknown as AiAdapter.Any);
+ * 
+ * // Use with AgentKit agent
+ * const agent = new Agent({
+ *   model,
+ *   tools: [/* your tools *\/],
+ * });
+ * ```
+ */
+
+export { A3MAdapter, createA3MAdapter } from "./adapter";
+export type {
+  A3MConfig,
+  A3MInferenceOptions,
+  A3MMessage,
+  A3MTool,
+  A3MToolCall,
+  A3MStreamChunk,
+  A3MResponse,
+  ToolChoice,
+} from "./types";

--- a/packages/agentkit-adapter/src/types.ts
+++ b/packages/agentkit-adapter/src/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Types for A3M Router AgentKit Adapter
+ */
+
+import { z } from "zod";
+
+/**
+ * Configuration for A3M Router
+ */
+export interface A3MConfig {
+  /** A3M Router base URL (default: http://localhost:8787) */
+  baseUrl?: string;
+  /** API key for A3M Router (if required) */
+  apiKey?: string;
+  /** Default model to use (optional - A3M will route automatically) */
+  defaultModel?: string;
+  /** Enable parallel ensemble mode */
+  parallel?: boolean;
+  /** Temperature for generation (0-2) */
+  temperature?: number;
+  /** Maximum tokens to generate */
+  maxTokens?: number;
+  /** Additional headers to send with each request */
+  headers?: Record<string, string>;
+}
+
+/**
+ * A3M-specific options for inference
+ */
+export interface A3MInferenceOptions {
+  /** Override the model for this call */
+  model?: string;
+  /** Enable parallel ensemble for this call */
+  parallel?: boolean;
+  /** Temperature (0-2) */
+  temperature?: number;
+  /** Maximum tokens */
+  maxTokens?: number;
+  /** Provider to use (bypass routing) */
+  provider?: string;
+  /** Stop sequences */
+  stop?: string[];
+  /** Retry on failure */
+  retry?: boolean;
+}
+
+/**
+ * Message format compatible with AgentKit
+ */
+export interface A3MMessage {
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+  name?: string;
+  toolCallId?: string;
+}
+
+/**
+ * Tool call format for A3M
+ */
+export interface A3MToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+/**
+ * Tool definition for A3M
+ */
+export interface A3MTool {
+  name: string;
+  description: string;
+  parameters?: z.ZodType<unknown>;
+  strict?: boolean;
+}
+
+/**
+ * Streaming chunk from A3M
+ */
+export interface A3MStreamChunk {
+  type: "text" | "tool_call" | "done" | "error";
+  content?: string;
+  toolCall?: A3MToolCall;
+  error?: string;
+}
+
+/**
+ * Response from A3M inference
+ */
+export interface A3MResponse {
+  content: string;
+  toolCalls?: A3MToolCall[];
+  model?: string;
+  provider?: string;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  finishReason?: "stop" | "length" | "tool_calls" | "content_filter";
+}
+
+/**
+ * Tool choice options
+ */
+export type ToolChoice = "auto" | "none" | { type: "function"; function: { name: string } };

--- a/packages/agentkit-adapter/src/util.ts
+++ b/packages/agentkit-adapter/src/util.ts
@@ -1,0 +1,13 @@
+/**
+ * Utility functions
+ */
+
+export const stringifyError = (err: unknown): string => {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === "string") {
+    return err;
+  }
+  return JSON.stringify(err);
+};

--- a/packages/agentkit-adapter/tsconfig.json
+++ b/packages/agentkit-adapter/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "examples"]
+}


### PR DESCRIPTION
## A3M Router AgentKit Adapter

Production-ready AgentKit adapter that routes LLM calls through A3M Router.

### Features

- **Drop-in AgentKit replacement** - Works with any AgentKit-compatible agent framework
- **Automatic model selection** - Routes to cheapest capable model across 47+ providers
- **Parallel ensemble** - Call multiple providers, pick the best answer
- **Streaming support** - Real-time token streaming
- **Tool calling** - Full function calling support

### Installation

```bash
npm install @a3m/agentkit-adapter
```

### Usage

```typescript
import { createAgentKitAdapter } from "@a3m/agentkit-adapter";

const adapter = createAgentKitAdapter({
  baseUrl: "http://localhost:8787",
  model: "auto",
  temperature: 0.7,
});

const response = await adapter.chat([
  { role: "user", content: "What is 2+2?" },
]);

console.log(response.content);   // "2+2 equals 4."
console.log(response.provider);  // "groq"
console.log(response.tier);      // "cheap"
```

### With Tools

```typescript
const adapter = createAgentKitAdapter({
  baseUrl: "http://localhost:8787",
  model: "auto",
  tools: [calculatorTool, searchTool],
});

const response = await adapter.chat(
  [{ role: "user", content: "What is 50 * 23?" }],
  [calculatorTool]
);
```

### Files

```
packages/agentkit-adapter/
├── src/
│   ├── adapter.ts    # Main adapter implementation
│   ├── types.ts      # TypeScript types
│   ├── index.ts      # Package entry
│   └── util.ts       # Utilities
├── examples/
│   └── agentkit-example.ts
├── package.json
└── README.md
```

### Related

- Kong plugin: https://github.com/Das-rebel/a3m-kong-plugin